### PR TITLE
add podspec file and revert name back to non-pillar so auto-linking doesnt break

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pillar-react-native-calendars",
+  "name": "react-native-calendars",
   "version": "0.0.1",
   "main": "src/index.js",
   "description": "React Native Calendar Components",

--- a/react-native-calendars.podspec
+++ b/react-native-calendars.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platforms    = { :ios => "9.0", :osx => "10.14" }
+
+  s.source       = { :git => "https://github.com/askpillar/react-native-calendars.git", :branch => "master" }
+  s.source_files  = "apple/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
We need this for RN to be able to autolink correctly